### PR TITLE
Fix ioctl_mutex deadlock

### DIFF
--- a/include/libv4l-rkmpp.h
+++ b/include/libv4l-rkmpp.h
@@ -282,6 +282,7 @@ struct rkmpp_context {
 	struct rkmpp_buf_queue capture;
 
 	pthread_mutex_t ioctl_mutex;
+	pthread_cond_t ioctl_cond;
 
 	pthread_t worker_thread;
 	pthread_cond_t worker_cond;

--- a/src/libv4l-rkmpp-dec.c
+++ b/src/libv4l-rkmpp-dec.c
@@ -412,6 +412,7 @@ static void *decoder_thread_fn(void *data)
 				  rkmpp_buffer, entry);
 		rkmpp_buffer_set_available(rkmpp_buffer);
 		pthread_mutex_unlock(&ctx->capture.queue_mutex);
+		pthread_cond_signal(&ctx->ioctl_cond);
 next_locked:
 		pthread_mutex_unlock(&ctx->ioctl_mutex);
 next:

--- a/src/libv4l-rkmpp-enc.c
+++ b/src/libv4l-rkmpp-enc.c
@@ -380,6 +380,7 @@ static void *encoder_thread_fn(void *data)
 				  rkmpp_buffer, entry);
 		rkmpp_buffer_set_available(rkmpp_buffer);
 		pthread_mutex_unlock(&ctx->capture.queue_mutex);
+		pthread_cond_signal(&ctx->ioctl_cond);
 next_locked:
 		pthread_mutex_unlock(&ctx->ioctl_mutex);
 next:

--- a/src/libv4l-rkmpp.c
+++ b/src/libv4l-rkmpp.c
@@ -664,7 +664,7 @@ int rkmpp_dqbuf(struct rkmpp_context *ctx, struct v4l2_buffer *buffer)
 			return -1;
 		}
 
-		usleep(1000);
+		pthread_cond_wait(&ctx->ioctl_cond, &ctx->ioctl_mutex);
 	}
 
 	pthread_mutex_lock(&queue->queue_mutex);
@@ -955,6 +955,7 @@ static void *plugin_init(int fd)
 	close(epollfd);
 
 	pthread_mutex_init(&ctx->ioctl_mutex, NULL);
+	pthread_cond_init(&ctx->ioctl_cond, NULL);
 	pthread_mutex_init(&ctx->output.queue_mutex, NULL);
 	pthread_mutex_init(&ctx->capture.queue_mutex, NULL);
 	pthread_cond_init(&ctx->worker_cond, NULL);


### PR DESCRIPTION
It fix the deadlock In my situation:
rkmpp_dqbuf on main thread holds ioctl_mutex while waiting for queue avaiable, but worker thread has no change to acquire ioctl_mutex to release the queue.